### PR TITLE
Rewrite pm2-windows-service

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/README.md
+++ b/README.md
@@ -4,25 +4,26 @@
 
 ### Windows Support
 
-Setup on Windows is largely based on [this excellent gist](https://gist.github.com/maxfierke/a85ba9d717d6e121405c).
+Unfortunately, PM2 has no built-in startup support for Windows. PM2's [documentation](https://pm2.keymetrics.io/docs/usage/startup/#windows-consideration) recommends using either `pm2-windows-service` or `pm2-windows-startup`. However, both of these projects have some real drawbacks.
 
-There are a couple issues that make automated deployment of a pm2 service difficult on Windows:
+`pm2-windows-startup` adds an entry to the registry to start pm2 after user login. Because it does not create a service, PM2 will not be running until a user has logged into the user interface, and will halt when they log out. It has not been updated since 2015.
 
-- Unlike on Linux, `pm2` has no built-in startup script support for Windows
-- The `npm` directory must be accessible to the Local Service user
-- The `pm2_home` folder must be writeable by the Local Service user
-- The `PM2_HOME` environmental variable must be set on a machine level
+`pm2-windows-service` uses `node-windows` to create a service that runs pm2. This is a much better approach, but it hasn't been maintained since 2018, has outdated dependencies that cause crashes on setup, and currently fails to run properly on Node 14. It also runs the service as the the `Local System` user instead of `Local Service`.
 
-When running on Windows, `pm2-installer` will do the following:
+This project creates its own Windows Service using the current version of `node-windows` and a series of PowerShell scripts inspired by [this excellent gist](https://gist.github.com/mauron85/e55b3b9d722f91366c50fddf2fca07a4) by [@maxfierke](https://github.com/maxfierke) & [@mauron85](https://github.com/mauron85).
 
-- Configure `npm` to keep it's global files in `C:\ProgramData\npm`, instead of keeping them in the current user's `%APPDATA%`
-- Install `pm2` globally (using an offline cache if one is available)
-- Create a folder at `C:\ProgramData\pm2` and set the `PM2_HOME` environmental variable to it at the machine level
+When running on Windows, `pm2-installer` will:
+
+- Configure `npm` to keep its global files in `C:\ProgramData\npm`, instead of keeping them in the current user's `%APPDATA%`
+- Install `pm2` globally, using an offline cache if necessary
+- Create the `C:\ProgramData\pm2` directory and set the `PM2_HOME` environmental variable at the machine level
 - Set permissions both the new `npm` and `pm2` folders so that the Local Service user may access them
-- Leverage a fork of `pm2-windows-service` to create a pm2 Windows service that will persist across reboots
+- Leverage `node-windows` to install a new Windows service
+- Use PowerShell to configure the service to run as the Local Service user (due to [node-windows#89](https://github.com/coreybutler/node-windows/issues/89))
+- Confirm the service is running properly
 - Install the `pm2-logrotate` module so that log files don't fill up the disk
 
-After that, `pm2` will be installed as a service. It will persist across reboots and continue running regardless of which user is logged in. To add your app, run `pm2 start app.js` from an admin command line interface. Make sure to run `pm2 save` to serialize the process list.
+After that, `pm2` will be running in the background the `Local Service` user. It will persist across reboots and continue running regardless of which user is logged in. To add your app, run `pm2 start app.js` from an admin command line interface. Make sure to run `pm2 save` to serialize the process list.
 
 ## Install
 
@@ -34,7 +35,8 @@ Copy the entire `pm2-installer` directory onto the target machine, then run:
 npm run setup
 ```
 
-On Windows, the `setup` script assumes you have already configured `npm` to use `prefix` and `cache` directories in a location accessible to the `LocalService` user. To do this automatically, run `configure` first:
+On Windows, the `setup` script assumes you have already configured `npm` to use `prefix` and `cache` directories in a location accessible to the `Local Service` user. If not, it will issue a warning and ask if you're sure you'd like to proceed.
+To set up `npm` automatically, run `configure` first:
 
 ```bash
 npm run configure
@@ -45,21 +47,21 @@ That's it.
 
 ## Offline Install
 
-`pm2-installer` is also designed to function without an internet connection. It does this by installing `pm2` on an internet-connected build machine to create a cache, then installing from cache when run on the deployment machine.
+`pm2-installer` is also designed to function without an internet connection. It does this by creating a cache on an internet-connected build machine, then installing from that cache when run on the offline deployment machine.
 
-On an internet-connected build machine of the same OS as the deployment target, run the following:
+On an internet-connected build machine running the same OS as the deployment target, run the following:
 
 ```bash
 npm run bundle
 ```
 
-This will install pm2 locally, and save the resources required to do so into the project's directory. Transfer the entire `pm2-installer` directory onto the deployment target, then run:
+This will populate the cache in the project's directory with the resources required to install offline. Transfer the entire `pm2-installer` directory onto the deployment target, then run:
 
 ```bash
 npm run setup
 ```
 
-`pm2-installer` will automatically detect the resources required to install without an internet connection and use them. Otherwise, it will attempt to download them from the npm registry.
+`pm2-installer` will check if it can contact the npm registry and install online if possible, or use the offline cache if not.
 
 ## Removal
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm2-installer",
-  "version": "3.0.0-ALPHA-1",
+  "version": "3.0.0",
   "description": "Install pm2 offline as a service on Windows or Linux",
   "license": "MIT",
   "author": "Jesse Youngblood",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "author": "Jesse Youngblood",
   "scripts": {
-    "preinstall": "echo 'Installing this package is not necessary. Run \"npm run setup\" to install pm2.'",
+    "postinstall": "echo 'Installing this package is not necessary. Run \"npm run setup\" to install pm2.'",
+    "lint": "eslint . && editorconfig-checker",
     "print-host": "node ./src/bundle-info/current.js",
     "print-config": "PowerShell -NoProfile -ExecutionPolicy Bypass src\\windows\\configure-print.ps1",
     "bundle": "node ./src/tools/script-for-os.js",
@@ -38,5 +39,10 @@
     "@innomizetech/pm2-windows-service": "^1.1.1",
     "pm2": "^4.4.0",
     "pm2-logrotate": "^2.7.0"
+  },
+  "devDependencies": {
+    "@jessety/eslint-config": "^1.0.5",
+    "editorconfig-checker": "^3.0.4",
+    "eslint": "^6.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,17 @@
 {
   "name": "pm2-installer",
-  "version": "2.5.0",
+  "version": "3.0.0-ALPHA-1",
   "description": "Install pm2 offline as a service on Windows or Linux",
   "license": "MIT",
   "author": "Jesse Youngblood",
+  "homepage": "https://github.com/jessety/pm2-installer#readme",
+  "bugs": {
+    "url": "https://github.com/jessety/pm2-installer/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jessety/pm2-installer.git"
+  },
   "scripts": {
     "postinstall": "echo 'Installing this package is not necessary. Run \"npm run setup\" to install pm2.'",
     "lint": "eslint . && editorconfig-checker",
@@ -35,10 +43,12 @@
     "remove:unix": "bash ./src/unix/remove.sh",
     "remove:default": "echo 'ERROR: Could not detect host platform'"
   },
-  "dependencies": {
-    "@innomizetech/pm2-windows-service": "^1.1.1",
-    "pm2": "^4.4.0",
-    "pm2-logrotate": "^2.7.0"
+  "windowsDependencies": {
+    "node-windows": "^1.0.0-beta.1"
+  },
+  "globalDependencies": {
+    "pm2": "4.4.0",
+    "pm2-logrotate": "2.7.0"
   },
   "devDependencies": {
     "@jessety/eslint-config": "^1.0.5",

--- a/src/bundle-info/bundle.js
+++ b/src/bundle-info/bundle.js
@@ -14,7 +14,7 @@ const exec = promisify(require('child_process').exec);
 // const colors = require('simple-log-colors');
 const colors = require('./colors');
 
-const { name, version, dependencies } = require('../../package.json');
+const { name, version } = require('../../package.json');
 
 const path = 'bundle.json';
 
@@ -30,6 +30,8 @@ async function info() {
     npm = stdout.trim();
   }
 
+  const node = process.version;
+
   const time = new Date().getTime() / 1000;
   const date = new Date().toLocaleDateString();
 
@@ -40,13 +42,12 @@ async function info() {
     time,
     date,
 
-    node: process.version,
+    node,
     npm,
 
     package: {
       name,
-      version,
-      dependencies
+      version
     },
 
     os: {

--- a/src/tools/echo-dependency.js
+++ b/src/tools/echo-dependency.js
@@ -2,21 +2,32 @@
 
 // Print the version of a specified dependency to the console
 
-const { dependencies } = require('../../package.json');
+const pkg = require('../../package.json');
 
-let [identifier] = process.argv.slice(2);
+let [identifier, type] = process.argv.slice(2);
+
+if (type === undefined) {
+  type = 'global';
+}
+
+let dependencies = {};
+
+if (type === 'windows') {
+  dependencies = pkg.windowsDependencies;
+} else if (type === 'global') {
+  dependencies = pkg.globalDependencies;
+} else if (type === 'dev') {
+  dependencies = pkg.devDependencies;
+} else {
+  process.exit();
+}
 
 if (identifier === undefined) {
   // No can do.
   process.exit();
 }
 
-// The dependencies we use are: 'pm2', 'pm2-windows-service', or 'pm2-logrotate'
-
-// pm2-windows-service is unmaintained, so we're using a fork
-if (identifier === 'pm2-windows-service') {
-  identifier = '@innomizetech/pm2-windows-service';
-}
+// The global dependencies we need are: 'pm2' and 'pm2-logrotate'
 
 if (dependencies[identifier] === undefined) {
   // Nope.

--- a/src/unix/bundle.sh
+++ b/src/unix/bundle.sh
@@ -14,8 +14,8 @@ mkdir -p $cache_folder
 rm -rf $cache_archive
 
 echo "Populating cache with all dependencies.."
-npm install --global-style --force --cache $cache_folder --loglevel=error --no-audit --no-fund $pm2_package
-npm install --global-style --force --cache $cache_folder --loglevel=error --no-audit --no-fund $pm2_logrotate_package
+npm install --no-save --global-style --force --cache $cache_folder --loglevel=error --no-audit --no-fund $pm2_package
+npm install --no-save --global-style --force --cache $cache_folder --loglevel=error --no-audit --no-fund $pm2_logrotate_package
 
 echo "Removing local npm_modules folder.."
 rm -rf node_modules

--- a/src/unix/remove.sh
+++ b/src/unix/remove.sh
@@ -4,7 +4,7 @@ echo "=== Remove ==="
 
 echo "Removing pm2-logrotate"
 pm2 delete pm2-logrotate --silent
-pm2 uninstall pm2-logrotate --silent 
+pm2 uninstall pm2-logrotate --silent
 
 echo "Removing pm2 service"
 pm2 unstartup

--- a/src/unix/setup.sh
+++ b/src/unix/setup.sh
@@ -24,7 +24,7 @@ if [ $? -eq 0 ]; then
 
   pm2 install $pm2_logrotate_package
 
-else 
+else
 
   echo "Cannot connect to the npm registry. Checking for offline bundle.."
 

--- a/src/unix/unbundle.sh
+++ b/src/unix/unbundle.sh
@@ -6,21 +6,21 @@ cache_folder="./.npm_cache";
 cache_archive="./bundle.tar.gz"
 bundle_file="./bundle.json";
 
-if [ -f $cache_archive ]; then 
+if [ -f $cache_archive ]; then
   echo "Cache archive detected, removing.."
   rm $cache_archive
 else
   echo "Cache archive not detected."
 fi
 
-if [ -d $cache_folder ]; then 
+if [ -d $cache_folder ]; then
   echo "Cache folder detected, removing.."
   rm -rf $cache_folder
 else
   echo "Cache folder not detected."
 fi
 
-if [ -f $bundle_file ]; then 
+if [ -f $bundle_file ]; then
   echo "Bundle info file detected, removing.."
   rm $bundle_file
 else

--- a/src/windows/bundle.ps1
+++ b/src/windows/bundle.ps1
@@ -3,8 +3,8 @@ Write-Host "=== Bundle ==="
 $Epoch = Get-Date
 
 $pm2_package = "$(node src/tools/echo-dependency.js pm2)"
-$pm2_service_package = "$(node src/tools/echo-dependency.js pm2-windows-service)";
 $pm2_logrotate_package = "$(node src/tools/echo-dependency.js pm2-logrotate)"
+$node_windows_package = "$(node src/tools/echo-dependency.js node-windows windows)"
 
 $cache_folder = ".\.npm_cache";
 $cache_archive_tar=".\bundle.tar.gz"
@@ -42,9 +42,9 @@ Write-Host "Populating cache folder with all dependencies.."
 
 $BeforePopulation = Get-Date
 
-npm install --global-style --force --cache $cache_folder --shrinkwrap false --loglevel=error --no-audit --no-fund $pm2_package
-npm install --global-style --force --cache $cache_folder --shrinkwrap false --loglevel=error --no-audit --no-fund $pm2_service_package
-npm install --global-style --force --cache $cache_folder --shrinkwrap false --loglevel=error --no-audit --no-fund $pm2_logrotate_package
+npm install --no-save --global-style --force --cache $cache_folder --shrinkwrap false --loglevel=error --no-audit --no-fund $pm2_package
+npm install --no-save --global-style --force --cache $cache_folder --shrinkwrap false --loglevel=error --no-audit --no-fund $pm2_logrotate_package
+npm install --no-save --global-style --force --cache $cache_folder --shrinkwrap false --loglevel=error --no-audit --no-fund $node_windows_package
 
 Write-Host "Populating cache took $([Math]::Floor($(Get-Date).Subtract($BeforePopulation).TotalSeconds)) seconds."
 

--- a/src/windows/check-service.ps1
+++ b/src/windows/check-service.ps1
@@ -1,0 +1,37 @@
+﻿param([string] $name = "pm2.exe")
+
+Write-Host "Confirm-Service -name `"$name`""
+
+# Create a filter to query for the service by
+
+$filter = "Name='$name'"
+
+# Query for the service, wait a second if we can't find it right away
+
+$attempt = 0
+$maxAttempts = 10
+$service = $null
+
+while (($null -eq $service -and $attempt -le ($maxAttempts - 1))) {
+
+  if ($attempt -ne 0) {
+    Start-Sleep -Milliseconds 250
+    Write-Host "Attempt #$($attempt + 1) to locate `"$name`" service.."
+  }
+
+  $service = Get-WMIObject -class Win32_Service -Filter $filter
+
+  $attempt = $attempt + 1
+}
+
+if ($null -eq $service) {
+  throw "Could not find `"$name`" service after $maxAttempts attempts."
+}
+
+Write-Host "Found `"$name`" service:"
+Write-Host "  State: $($service.State)"
+Write-Host "  Status: $($service.Status)"
+Write-Host "  Started: $($service.Started)"
+Write-Host "  Start Mode: $($service.StartMode)"
+Write-Host "  Service Type: $($service.ServiceType)"
+Write-Host "  Start Name: $($service.StartName)"

--- a/src/windows/configure-check.ps1
+++ b/src/windows/configure-check.ps1
@@ -29,7 +29,7 @@ if ($valid -eq $false) {
   $confirmation = Read-Host -Prompt "Are you sure you want to proceed anyway? (Y/N)"
 
   while ($confirmation -ne "y" -and $confirmation -ne "Y") {
-    
+
     if ($confirmation -eq 'n' -or $confirmation -eq 'N') {
       # Inform the script that called this that we're not going forward
       Write-Output "n"

--- a/src/windows/configure-policy.ps1
+++ b/src/windows/configure-policy.ps1
@@ -21,13 +21,13 @@ if ($Force -eq $false) {
   $confirmation = Read-Host -Prompt "Would you like to update it to `"$preferred`"? (Y/N)"
 
   while ($confirmation -ne "y" -and $confirmation -ne "Y") {
-    
+
     if ($confirmation -eq 'n' -or $confirmation -eq 'N') {
       Write-Output $false
       exit
     }
 
-     $confirmation = Read-Host -Prompt "(Y/N)"
+    $confirmation = Read-Host -Prompt "(Y/N)"
   }
 }
 

--- a/src/windows/configure-setup.ps1
+++ b/src/windows/configure-setup.ps1
@@ -78,7 +78,7 @@ function Update-Path {
 
     # Also update session path
     $Env:Path += ";$NewPath"
-  
+
   } else {
 
     Write-Host "Path already contains $NewPath, no need to update it."

--- a/src/windows/configure-setup.ps1
+++ b/src/windows/configure-setup.ps1
@@ -1,5 +1,5 @@
 param(
-  [string] $Directory = "c:\ProgramData\npm"
+  [string] $Directory = "$($env:ProgramData)\npm"
 )
 
 Write-Host "=== Configuring npm to use $Directory ==="

--- a/src/windows/remove-logrotate.ps1
+++ b/src/windows/remove-logrotate.ps1
@@ -10,7 +10,8 @@ if (Get-Command "pm2" -ErrorAction SilentlyContinue) {
 
 } else {
 
-  Write-Host "Command `"pm2`" not found, potentially because it has already been uninstalled. Not removing log rotation, since pm2 itself has alrady been removed."
+  Write-Host "Command `"pm2`" not found, potentially because it has already been uninstalled."
+  Write-Host "Not removing log rotation, since pm2 itself has already been removed."
 }
 
 Write-Host "=== Remove Log Rotation Complete ==="

--- a/src/windows/remove-packages.ps1
+++ b/src/windows/remove-packages.ps1
@@ -1,7 +1,13 @@
 Write-Host "=== Remove Packages ==="
 
+Write-Host "Unlinking node-windows.."
+
+npm unlink node-windows --loglevel=error --no-fund --no-audit
+
+Write-Host "Uninstalling packages.."
+
 npm uninstall --global --loglevel=error "pm2"
-npm uninstall --global --loglevel=error "@innomizetech/pm2-windows-service"
 npm uninstall --global --loglevel=error "pm2-logrotate"
+npm uninstall --global --loglevel=error "node-windows"
 
 Write-Host "=== Remove Packages Complete ==="

--- a/src/windows/remove-service.ps1
+++ b/src/windows/remove-service.ps1
@@ -108,7 +108,7 @@ if (($null -ne $PM2_HOME) -and (Test-Path $PM2_HOME)) {
   Remove-Item $PM2_HOME -Recurse -Force | Out-Null
 }
 
-$PM2_PARENT_FOLDER = "C:\ProgramData\pm2"
+$PM2_PARENT_FOLDER = "$($env:ProgramData)\pm2"
 if (($null -ne $PM2_PARENT_FOLDER) -and (Test-Path $PM2_PARENT_FOLDER)) {
 
   Write-Host "Deleting `"$PM2_PARENT_FOLDER`""

--- a/src/windows/remove-service.ps1
+++ b/src/windows/remove-service.ps1
@@ -1,40 +1,132 @@
 Write-Host "=== Remove Service ==="
 
-if (Get-Command "pm2" -ErrorAction SilentlyContinue) {
-  Write-Host "Deleting all pm2 processes.."
-  pm2 uninstall pm2-logrotate --silent
-  pm2 save --force --silent
-} else {
-  Write-Host "Command pm2 not found, potentially because it has already been uninstalled."
+$PM2_HOME = $env:PM2_HOME;
+$PM2_SERVICE_DIRECTORY = $env:PM2_SERVICE_DIRECTORY;
+
+function Stop-Service {
+  param([string] $name)
+
+  # Create a filter to query for the service by
+
+  $filter = "Name='$name'"
+
+  # Query for the service, wait a second if we can't find it right away
+
+  $attempt = 0
+  $maxAttempts = 10
+  $service = $null
+
+  while (($null -eq $service -and $attempt -le ($maxAttempts - 1))) {
+
+    if ($attempt -ne 0) {
+      Start-Sleep -Milliseconds 500
+      Write-Host "Attempt #$($attempt) to locate service `"$name`" failed, trying again.."
+    }
+
+    $service = Get-WMIObject -class Win32_Service -Filter $filter
+
+    $attempt = $attempt + 1
+  }
+
+  if ($null -eq $service) {
+    Write-Host "Could not find `"$name`" service after $maxAttempts attempts. It has likely already been uninstalled."
+    return;
+  }
+
+  Write-Host "Found `"$name`" service:"
+  Write-Host "  State: $($service.State)"
+  Write-Host "  Status: $($service.Status)"
+  Write-Host "  Started: $($service.Started)"
+  Write-Host "  Start Mode: $($service.StartMode)"
+  Write-Host "  Service Type: $($service.ServiceType)"
+  Write-Host "  Start Name: $($service.StartName)"
+
+  if ($service.State -eq 'Stopped') {
+    Write-Host "Service is already stopped."
+    return;
+  }
+
+  Write-Host "Sending stop command, this may take a minute.."
+
+  $response = $service.StopService()
+
+  if ($response.ReturnValue -ne 0) {
+    $message = Get-Service-Error-For-Code($response.ReturnValue)
+    throw "Could not stop service: $message"
+  }
+
+  # Wait until it has stopped
+
+  $service = Get-WMIObject -class Win32_Service -Filter $filter
+
+  Write-Host "  Service state is: $($service.State)"
+
+  while ($service.State -ne 'Stopped') {
+
+    Start-Sleep -Milliseconds 250
+    $service = Get-WMIObject -class Win32_Service -Filter $filter
+    Write-Host "  Service state is: $($service.State)"
+  }
+
+  Write-Host "Service stopped."
 }
 
-$command = "pm2-service-uninstall"
+Write-Host "Stopping service, this may take a minute or so.."
+Stop-Service -name "pm2.exe"
 
-if (Get-Command $command -ErrorAction SilentlyContinue) {
-  Write-Host "Running $command.."
-  & $command
-} else {
-  Write-Host "Command $command not found, likely because it has already been uninstalled."
+Write-Host "Running pm2 kill.."
+pm2 kill --silent
+
+$wd = (Get-Item -Path '.\' -Verbose).FullName
+
+if (($null -ne $PM2_SERVICE_DIRECTORY) -and (Test-Path $PM2_SERVICE_DIRECTORY)) {
+  Set-Location $PM2_SERVICE_DIRECTORY
 }
 
-Write-Host "Resetting system environmental variables"
+Write-Host "Running Node service uninstall script.."
 
-[Environment]::SetEnvironmentVariable("PM2_HOME", $null, "Machine")
-[Environment]::SetEnvironmentVariable("PM2_SERVICE_PM2_DIR", $null, "Machine")
-# [Environment]::SetEnvironmentVariable("PM2_SERVICE_SCRIPTS", $null, "Machine")
+node "$wd\src\windows\service-management\uninstall.js" $PM2_SERVICE_DIRECTORY
 
-[Environment]::SetEnvironmentVariable("SET_PM2_HOME", $null, "Machine")
-[Environment]::SetEnvironmentVariable("SET_PM2_SERVICE_PM2_DIR", $null, "Machine")
-[Environment]::SetEnvironmentVariable("SET_PM2_SERVICE_SCRIPTS", $null, "Machine")
+if ($? -ne $True) {
+  Set-Location $wd
+  throw "Service uninstall script failed."
+}
 
+if (($null -ne $PM2_SERVICE_DIRECTORY) -and (Test-Path $PM2_SERVICE_DIRECTORY)) {
+  Write-Host "Unlinking node-windows in $PM2_SERVICE_DIRECTORY"
+  npm unlink node-windows --loglevel=error --no-fund --no-audit
 
-Write-Host "Resetting shell environmental variables"
+  Set-Location $wd
+
+  Write-Host "Deleting pm2 service directory `"$PM2_SERVICE_DIRECTORY`""
+  Remove-Item $PM2_SERVICE_DIRECTORY -Recurse -Force | Out-Null
+}
+
+if (($null -ne $PM2_HOME) -and (Test-Path $PM2_HOME)) {
+
+  Write-Host "Deleting pm2 home directory `"$PM2_HOME`""
+  Remove-Item $PM2_HOME -Recurse -Force | Out-Null
+}
+
+$PM2_PARENT_FOLDER = "C:\ProgramData\pm2"
+if (($null -ne $PM2_PARENT_FOLDER) -and (Test-Path $PM2_PARENT_FOLDER)) {
+
+  Write-Host "Deleting `"$PM2_PARENT_FOLDER`""
+  Remove-Item $PM2_PARENT_FOLDER -Recurse -Force | Out-Null
+}
+
+Write-Host "Resetting shell environmental variables.."
 
 $env:PM2_HOME = $null
-$env:PM2_SERVICE_PM2_DIR = $null
-$env:PM2_SERVICE_PM2_DIR = $null
-$env:SET_PM2_HOME = $null
-$env:SET_PM2_SERVICE_PM2_DIR = $null
-$env:SET_PM2_SERVICE_SCRIPTS = $null
+$env:PM2_INSTALL_DIRECTORY = $null
+$env:PM2_SERVICE_DIRECTORY = $null
+
+Write-Host "Resetting machine environmental variables.."
+
+[Environment]::SetEnvironmentVariable("PM2_HOME", $env:PM2_HOME, "Machine")
+[Environment]::SetEnvironmentVariable("PM2_INSTALL_DIRECTORY", $env:PM2_INSTALL_DIRECTORY, "Machine")
+[Environment]::SetEnvironmentVariable("PM2_SERVICE_DIRECTORY", $env:PM2_SERVICE_DIRECTORY, "Machine")
+
+Set-Location $wd
 
 Write-Host "=== Remove Service Complete ==="

--- a/src/windows/remove-service.ps1
+++ b/src/windows/remove-service.ps1
@@ -93,8 +93,8 @@ if ($? -ne $True) {
 }
 
 if (($null -ne $PM2_SERVICE_DIRECTORY) -and (Test-Path $PM2_SERVICE_DIRECTORY)) {
-  Write-Host "Unlinking node-windows in $PM2_SERVICE_DIRECTORY"
-  npm unlink node-windows --loglevel=error --no-fund --no-audit
+  # Write-Host "Unlinking node-windows in $PM2_SERVICE_DIRECTORY"
+  # npm unlink node-windows --loglevel=error --no-fund --no-audit
 
   Set-Location $wd
 

--- a/src/windows/service-management/install.js
+++ b/src/windows/service-management/install.js
@@ -1,0 +1,82 @@
+'use strict';
+
+console.log(`service-management\\install Installing`);
+
+try {
+  require('node-windows');
+} catch (error) {
+  console.error('Could not load "node-windows", likely because it has already been uninstalled.');
+  process.exit(1);
+}
+
+const path = require('path');
+const { Service } = require('node-windows');
+
+// Ensure all the environmental variables we need are populated
+
+for (const key of ['PM2_HOME', 'PM2_INSTALL_DIRECTORY', 'PM2_SERVICE_DIRECTORY']) {
+  if (process.env[key] === undefined) {
+    console.error(`ERROR: $env:${key} is undefined. Halting installation.`);
+    console.log(`Please set $env:${key} and run this script again.`);
+    process.exit(1);
+  }
+}
+
+let [directory, user, name, description] = process.argv.slice(2);
+
+// Pull the process directory, service name, and service description from the script parameters or pricess env, or use a default
+directory = directory || process.env.PM2_SERVICE_DIRECTORY || 'c:\\ProgramData\\pm2\\service\\';
+name = name || process.env.PM2_SERVICE_NAME || 'PM2';
+description = description || process.env.PM2_SERVICE_DESCRIPTION || 'Node process manager';
+
+const service = new Service({
+  name,
+  description,
+  workingDirectory: directory,
+  script: path.join(directory, 'index.js'),
+  nodeOptions: ['--harmony'],
+  stopparentfirst: true
+});
+
+console.log(`Installing service "${name}" at "${directory}"`);
+
+if (typeof user === 'string' && user !== '') {
+
+  service.logOnAs.account = user;
+  service.logOnAs.password = ''; // This is left intentionally blank
+
+  console.log(`Running as "${user}"`);
+}
+
+// Install the service
+
+// If an error occurs, print it and exit 1
+service.on('error', error => {
+  console.error(error);
+  process.exit(1);
+});
+
+// If the service is already installed, exit 0
+service.on('alreadyinstalled', () => {
+  console.log('Already installed.');
+  console.log(`service-management\\install Complete`);
+  process.exit(0);
+});
+
+// Once the service is installed, start it
+service.on('install', () => {
+  // console.log(`Installed! Starting..`);
+  // service.start();
+  console.log(`service-management\\install Complete`);
+  process.exit(0);
+});
+
+// Once the service has started, exit
+// service.on('start', () => {
+//   console.log(`Started!`);
+//   console.log(`service-management\\install Complete`);
+//   process.exit(0);
+// });
+
+// Install the script as a service.
+service.install();

--- a/src/windows/service-management/uninstall.js
+++ b/src/windows/service-management/uninstall.js
@@ -1,0 +1,67 @@
+'use strict';
+
+console.log(`service-management\\uninstall Uninstalling`);
+
+try {
+  require('node-windows');
+} catch (error) {
+  console.error('Could not load "node-windows", likely because it has already been uninstalled.');
+  process.exit(0);
+}
+
+const path = require('path');
+const { Service } = require('node-windows');
+
+// Create a "Service" object
+
+let [directory, user, name, description] = process.argv.slice(2);
+
+// Pull the process directory, service name, and service description from the script parameters or pricess env, or use a default
+directory = directory || process.env.PM2_SERVICE_DIRECTORY || 'c:\\ProgramData\\pm2\\service\\';
+name = name || process.env.PM2_SERVICE_NAME || 'PM2';
+description = description || process.env.PM2_SERVICE_DESCRIPTION || 'Node process manager';
+
+const service = new Service({
+  name,
+  description,
+  workingDirectory: directory,
+  script: path.join(directory, 'index.js'),
+  nodeOptions: ['--harmony'],
+  stopparentfirst: true
+});
+
+console.log(`Uninstalling service "${name}" at "${directory}"`);
+
+if (typeof user === 'string' && user !== '') {
+
+  service.logOnAs.account = user;
+  service.logOnAs.password = ''; // This is left intentionally blank
+
+  console.log(`Running as "${user}"`);
+}
+
+// Remove the service
+
+// If an error occurs, print it and exit 1
+service.on('error', error => {
+  console.error(error);
+  process.exit(1);
+});
+
+// If the service is already uninstalled, exit 0
+service.on('alreadyuninstalled', () => {
+  console.log('Service already uninstalled.');
+  console.log(`service-management\\uninstall Complete`);
+  process.exit(0);
+});
+
+// Once the service is uninstalled, exit 0
+service.on('uninstall', () => {
+  console.log('Service uninstalled.');
+  console.log(`service-management\\uninstall Complete`);
+  process.exit(0);
+});
+
+console.log('Uninstalling service..');
+
+service.uninstall();

--- a/src/windows/service/.npmrc
+++ b/src/windows/service/.npmrc
@@ -1,0 +1,2 @@
+package-lock=false
+loglevel=error

--- a/src/windows/service/env.js
+++ b/src/windows/service/env.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const path = require('path');
+const process = require('process');
+const { execSync } = require('child_process');
+
+// Load all the ENV values we need
+
+function installDirectory() {
+
+  const key = 'PM2_INSTALL_DIRECTORY';
+
+  let value = process.env[key];
+
+  if (value !== undefined && value !== '') {
+    return value;
+  }
+
+  // Attempt to determine where pm2 is likely installed
+
+  const { stdout, stderr } = execSync('npm config get prefix --global');
+
+  if (stderr.trim() !== '') {
+    console.log(`$env:${key} is blank, and we can't estimate the location manually.`);
+    throw new Error(stderr.trim());
+  }
+
+  value = path.join(stdout.trim(), 'node_modules', 'pm2');
+
+  console.warn(`$env:${key} is blank, assuming "${value}"`);
+
+  process.env[key] = value;
+
+  return value;
+}
+
+function homeDirectory() {
+
+  const key = 'PM2_HOME';
+
+  let value = process.env[key];
+
+  if (value !== undefined && value !== '') {
+    return value;
+  }
+
+  value = `C:\\ProgramData\\pm2\\home\\`;
+
+  console.warn(`$env:${key} is blank, assuming "${value}"`);
+
+  process.env[key] = value;
+
+  return value;
+}
+
+function serviceDirectory() {
+
+  const key = 'PM2_SERVICE_DIRECTORY';
+
+  let value = process.env[key];
+
+  if (value !== undefined && value !== '') {
+    // console.log(`$env:${key} is: ${value}`);
+    return value;
+  }
+
+  value = `C:\\ProgramData\\pm2\\service\\`;
+
+  console.warn(`$env:${key} is blank, assuming "${value}"`);
+
+  process.env[key] = value;
+
+  return value;
+}
+
+// Figure out where this service is installed
+
+const PM2_SERVICE_DIRECTORY = serviceDirectory();
+
+// Discern the location of the PM2_HOME directory
+
+const PM2_HOME = homeDirectory();
+
+// Acquire a reference to the global pm2 installation
+
+const PM2_INSTALL_DIRECTORY = installDirectory();
+
+module.exports = { PM2_HOME, PM2_INSTALL_DIRECTORY, PM2_SERVICE_DIRECTORY };

--- a/src/windows/service/index.js
+++ b/src/windows/service/index.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const os = require('os');
+const process = require('process');
+const { promisify } = require('util');
+
+const output = require('./output.js');
+const { PM2_HOME, PM2_INSTALL_DIRECTORY, PM2_SERVICE_DIRECTORY } = require('./env.js');
+
+output.log(`\n\n\nStarting: ${new Date().toLocaleString()}`);
+
+output.log(`PM2_HOME:              ${PM2_HOME}`);
+output.log(`PM2_SERVICE_DIRECTORY: ${PM2_SERVICE_DIRECTORY}`);
+output.log(`PM2_INSTALL_DIRECTORY: ${PM2_INSTALL_DIRECTORY}`);
+
+output.log(`Working directory:     ${process.cwd()}`);
+output.log(`Running as user:       ${os.userInfo().username}`);
+
+// Make sure to set the PM2_HOME in the process env, becasue pm2 pulls from process.env
+process.env.PM2_HOME = PM2_HOME;
+
+// Make pm2 more verbose
+process.env.PM2_DEBUG = true;
+
+// Require `pm2` from its global install location
+const pm2 = require(PM2_INSTALL_DIRECTORY);
+
+// Define a couple settings
+pm2.daemon_mode = false;
+pm2.Client.daemon_mode = false;
+
+// Listen for events
+pm2.launchBus((error, bus) => {
+
+  if (error) {
+    output.error('Caught error launching message bus:', error);
+    return;
+  }
+
+  output.log('Successfully launched message bus.');
+
+  // bus.on('*', (type, message) => output.log('pm2 bus', type, message));
+  // bus.on('log:out', (message) => output.log('pm2bus:out', message));
+  // bus.on('log:err', (message) => output.error('pm2bus:err', message));
+  // bus.on('log:PM2', message => console.log(message.data.trim()));
+
+  bus.on('process:event', message => {
+    const { event, process, manually } = message;
+    const { name, namespace, version } = process;
+
+    output.log(`${namespace ? `${namespace}/` : ''}${name}@${version} - ${event} - ${manually ? 'MANUAL' : 'AUTOMATED'}`);
+  });
+});
+
+output.log('Starting pm2..');
+
+pm2.connect(true, error => {
+
+  if (error) {
+    output.error('Caught error starting pm2:', error);
+    process.exit(1);
+  }
+
+  output.log('Successfully started pm2.');
+
+  // If a pm2 dump exists, resurrect all the processes set there
+  // If not, the callback will never be executed, and we're done.
+
+  pm2.resurrect(error => {
+
+    if (error) {
+      output.error('Caught error resurrecting pm2 processes:', error);
+      return;
+    }
+
+    output.log('Resurrection successful. Listing processes..');
+
+    pm2.list((error, list) => {
+
+      if (error) {
+        output.warn(`Caught error listing processes:`, error);
+        return;
+      }
+
+      if (list.length === 0) {
+        output.log(`Running 0 processes.`);
+        return;
+      }
+
+      output.log(`Running ${list.length} process${list.length !== 1 ? 'es' : ''}: ${list.map(process => process.name).join(', ')}`);
+    });
+  });
+});
+
+// Handle process exits
+
+process.once('beforeExit', async (code) => {
+
+  output.log(`beforeExit code ${code}`);
+
+  if (pm2) {
+
+    output.log(`Killing pm2 daemon..`);
+    await promisify(pm2.killDaemon);
+
+    output.log(`Disconnecting from pm2..`);
+    await promisify(pm2.disconnect);
+  }
+});
+
+const handle = (type) => output.log(`Caught ${type}`);
+for (const key of ['SIGINT', 'SIGHUP', 'SIGTERM']) {
+  process.on(key, () => handle(key));
+}
+
+process.once('exit', (code) => {
+  output.log(`exit code ${code}`);
+});
+
+process.on('uncaughtException', async error => {
+  output.log(`${new Date().toLocaleString()} service\\index.js Uncaught Exception`, error.message, (error.stack !== undefined) ? error.stack : undefined);
+  process.exit(1);
+});

--- a/src/windows/service/output.js
+++ b/src/windows/service/output.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// Pull references to the console functions, because PM2 replaces the global console object after we start it
+const {
+  log: consoleLog,
+  warn: consoleWarn,
+  error: consoleError
+} = console;
+
+/**
+ * Flatten parameters of any type into a string
+ * @param  {...any} params
+ */
+function flatten(...params) {
+
+  const flattened = params.map(item => {
+
+    if (['string', 'boolean', 'number'].includes(typeof item)) {
+      return item;
+    }
+
+    if (item instanceof Error) {
+
+      item = {
+        ...item,
+        message: item.message,
+        stack: item.stack,
+        name: item.name
+      };
+    }
+
+    try {
+      return JSON.stringify(item, null, '  ');
+    } catch (error) {
+      return '[Unserializable object]';
+    }
+  });
+
+  return flattened.join(' ');
+}
+
+/**
+ * Write a message to the log file, if we can discern where the log file is supposed to be
+ * @param {string} type - LOG, WARNING, or ERROR. Or anything else, really.
+ * @param {boolean} date - whether to write the timestamp to the log file or not
+ * @param  {...any} out
+ */
+function write(type = 'LOG', date = true, ...out) {
+
+  const { PM2_SERVICE_DIRECTORY } = process.env;
+
+  if (PM2_SERVICE_DIRECTORY === undefined || PM2_SERVICE_DIRECTORY === '') {
+    return;
+  }
+
+  const filepath = path.join(PM2_SERVICE_DIRECTORY, 'service.log');
+
+  let string = `\n`;
+
+  if (date === true) {
+    string += `${new Date().toLocaleString()}: `;
+  }
+
+  if (type !== 'LOG') {
+    string += `${type}: `;
+  }
+  string += flatten(...out);
+
+  try {
+    fs.appendFileSync(filepath, string);
+  } catch (error) {
+    consoleError('Failed to write to log file:', error);
+  }
+}
+
+const log = (...out) => {
+  consoleLog('pm2-service:', ...out);
+  write('LOG', true, ...out);
+};
+
+const warn = (...out) => {
+  consoleWarn('pm2-service:', ...out);
+  write('WARNING', true, ...out);
+};
+
+const error = (...out) => {
+  consoleError('pm2-service:', ...out);
+  write('ERROR', true, ...out);
+};
+
+// Replace the console functions so we can write output from pm2 to our log file as well
+
+console.log = (...out) => {
+  consoleLog(...out);
+  write('LOG', false, ...out);
+};
+
+console.warn = (...out) => {
+  consoleWarn(...out);
+  write('WARNING', false, ...out);
+};
+
+console.error = (...out) => {
+  consoleError(...out);
+  write('ERROR', false, ...out);
+};
+
+module.exports = { log, warn, error };

--- a/src/windows/service/package.json
+++ b/src/windows/service/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "pm2-service",
+  "description": "Node process manager service - created by pm2-installer",
+  "main": "index.js",
+  "type": "commonjs",
+  "homepage": "https://github.com/jessety/pm2-installer",
+  "license": "MIT",
+  "private": true
+}

--- a/src/windows/setup-logrotate.ps1
+++ b/src/windows/setup-logrotate.ps1
@@ -4,13 +4,13 @@ Write-Host "=== Adding Log Rotation ==="
 node src\tools\npm-online.js
 
 if ($? -eq $True) {
-  
+
   $logrotate_package = "$(node src/tools/echo-dependency.js pm2-logrotate)"
 
   Write-Host "Installing $logrotate_package online.."
 
   pm2 install $logrotate_package --silent
-  
+
 } else {
 
   $logrotate_directory = "$(npm config get prefix)\node_modules\pm2-logrotate\"

--- a/src/windows/setup-logrotate.ps1
+++ b/src/windows/setup-logrotate.ps1
@@ -21,6 +21,7 @@ if ($? -eq $True) {
   $wd = (Get-Item -Path '.\' -Verbose).FullName
 
   Set-Location $logrotate_directory
+
   pm2 install . --silent
 
   # Go back to where we were

--- a/src/windows/setup-packages.ps1
+++ b/src/windows/setup-packages.ps1
@@ -3,16 +3,21 @@ Write-Host "=== Install Packages ==="
 $Epoch = Get-Date
 
 $pm2_package = "$(node src/tools/echo-dependency.js pm2)"
-$pm2_service_package = "$(node src/tools/echo-dependency.js pm2-windows-service)";
 $pm2_logrotate_package = "$(node src/tools/echo-dependency.js pm2-logrotate)"
+$node_windows_package = "$(node src/tools/echo-dependency.js node-windows windows)"
 
-$cache_folder = ".\.npm_cache";
+$cache_folder = ".\.npm_cache"
 $cache_archive_tar = ".\bundle.tar.gz"
-$cache_archive_zip = ".\bundle.zip";
-$bundle_info = ".\bundle.json";
+$cache_archive_zip = ".\bundle.zip"
+$bundle_info = ".\bundle.json"
 
 # Print out the versions of this package, node, and npm for this host
 node src\bundle-info\current.js
+
+Write-Host "Using: "
+Write-Host " $pm2_package"
+Write-Host " $pm2_logrotate_package"
+Write-Host " $node_windows_package"
 
 # Check connectivity to registry.npmjs.org
 node src\tools\npm-online.js
@@ -24,8 +29,8 @@ if ($? -eq $True) {
   $PriorToInstall = Get-Date
 
   npm install --global --loglevel=error --no-audit --no-fund $pm2_package
-  npm install --global --loglevel=error --no-audit --no-fund $pm2_service_package
   npm install --global --loglevel=error --no-audit --no-fund $pm2_logrotate_package
+  npm install --global --loglevel=error --no-audit --no-fund $node_windows_package
 
   Write-Host "Installing packages took $([Math]::Floor($(Get-Date).Subtract($PriorToInstall).TotalSeconds)) seconds."
 
@@ -97,8 +102,8 @@ if ($? -eq $True) {
   $PriorToInstall = Get-Date
 
   npm install --global --offline --cache $cache_folder --shrinkwrap false --loglevel=error --no-audit --no-fund $pm2_package
-  npm install --global --offline --cache $cache_folder --shrinkwrap false --loglevel=error --no-audit --no-fund $pm2_service_package
   npm install --global --offline --cache $cache_folder --shrinkwrap false --loglevel=error --no-audit --no-fund $pm2_logrotate_package
+  npm install --global --offline --cache $cache_folder --shrinkwrap false --loglevel=error --no-audit --no-fund $node_windows_package
 
   Write-Host "Installing packages took $([Math]::Floor($(Get-Date).Subtract($PriorToInstall).TotalSeconds)) seconds."
 
@@ -109,11 +114,14 @@ if ($? -eq $True) {
   # This will probably not work.
 
   npm install --global --loglevel=error --no-audit --no-fund $pm2_package
-  npm install --global --loglevel=error --no-audit --no-fund $pm2_service_package
   npm install --global --loglevel=error --no-audit --no-fund $pm2_logrotate_package
+  npm install --global --loglevel=error --no-audit --no-fund $node_windows_package
 }
 
-# Enable execution of pm2's powershell script, so the current user can interact with pm2
+Write-Host "Linking node-windows.."
+npm link node-windows --loglevel=error --no-fund --no-audit
+
+# Enable execution of pm2's powershell script, so the current user can interact with the pm2 powershell script
 $script_path = "$(npm config get prefix)\pm2.ps1"
 if (Test-Path $script_path) {
 
@@ -121,6 +129,6 @@ if (Test-Path $script_path) {
   Unblock-File -Path $script_path
 }
 
-$TotalDuration = $(Get-Date).Subtract($Epoch);
+$TotalDuration = $(Get-Date).Subtract($Epoch)
 
 Write-Host "=== Install Packages Complete: took $([Math]::Floor($TotalDuration.TotalSeconds)) seconds ==="

--- a/src/windows/setup-packages.ps1
+++ b/src/windows/setup-packages.ps1
@@ -7,7 +7,7 @@ $pm2_service_package = "$(node src/tools/echo-dependency.js pm2-windows-service)
 $pm2_logrotate_package = "$(node src/tools/echo-dependency.js pm2-logrotate)"
 
 $cache_folder = ".\.npm_cache";
-$cache_archive_tar=".\bundle.tar.gz"
+$cache_archive_tar = ".\bundle.tar.gz"
 $cache_archive_zip = ".\bundle.zip";
 $bundle_info = ".\bundle.json";
 
@@ -22,13 +22,13 @@ if ($? -eq $True) {
   Write-Host "Installing packages.."
 
   $PriorToInstall = Get-Date
-  
+
   npm install --global --loglevel=error --no-audit --no-fund $pm2_package
   npm install --global --loglevel=error --no-audit --no-fund $pm2_service_package
   npm install --global --loglevel=error --no-audit --no-fund $pm2_logrotate_package
 
   Write-Host "Installing packages took $([Math]::Floor($(Get-Date).Subtract($PriorToInstall).TotalSeconds)) seconds."
-  
+
 } elseif ((Test-Path $cache_archive_tar) -or (Test-Path $cache_archive_zip) -or (Test-Path $cache_folder)) {
 
   Write-Host "Cannot connect to the npm registry. Checking for offline bundle.."

--- a/src/windows/setup-service.ps1
+++ b/src/windows/setup-service.ps1
@@ -1,6 +1,6 @@
 param(
-  [string] $PM2_HOME = "C:\ProgramData\pm2\home",
-  [string] $PM2_SERVICE_DIRECTORY = "C:\ProgramData\pm2\service"
+  [string] $PM2_HOME = "$($env:ProgramData)\pm2\home",
+  [string] $PM2_SERVICE_DIRECTORY = "$($env:ProgramData)\pm2\service"
 )
 
 $ErrorActionPreference = "Stop"

--- a/src/windows/setup-service.ps1
+++ b/src/windows/setup-service.ps1
@@ -1,155 +1,106 @@
-# Deploys PM2 as a Windows service
-# Adapted from: https://gist.github.com/mauron85/e55b3b9d722f91366c50fddf2fca07a4
-
-param([string] $Directory = "C:\ProgramData\pm2")
+param(
+  [string] $PM2_HOME = "C:\ProgramData\pm2\home",
+  [string] $PM2_SERVICE_DIRECTORY = "C:\ProgramData\pm2\service"
+)
 
 $ErrorActionPreference = "Stop"
 
-# Query for the name of the Local Service user by its security identifier
-# https://support.microsoft.com/en-us/help/243330/well-known-security-identifiers-in-windows-operating-systems
-$localServiceSID = New-Object System.Security.Principal.SecurityIdentifier("S-1-5-19")
-$User = ($localServiceSID.Translate([System.Security.Principal.NTAccount])).Value
+function Set-ENV {
+  $env:PM2_HOME = $PM2_HOME
+  $env:PM2_INSTALL_DIRECTORY = $PM2_INSTALL_DIRECTORY
+  $env:PM2_SERVICE_DIRECTORY = $PM2_SERVICE_DIRECTORY
 
-Write-Host "=== Creating Service ==="
-Write-Host "  PM2_HOME: $Directory"
-Write-Host "  User:     $User"
+  [Environment]::SetEnvironmentVariable("PM2_HOME", $env:PM2_HOME, "Machine")
+  [Environment]::SetEnvironmentVariable("PM2_INSTALL_DIRECTORY", $env:PM2_INSTALL_DIRECTORY, "Machine")
+  [Environment]::SetEnvironmentVariable("PM2_SERVICE_DIRECTORY", $env:PM2_SERVICE_DIRECTORY, "Machine")
+}
 
-function New-PM2-Home {
-  Write-Host "Attempting to create `"$Directory`" and give FullControl to `"$User`""
+function New-Directory {
+  param([string] $Directory)
+
+  Write-Host "Attempting to create `"$Directory`""
 
   if (Test-Path $Directory) {
-    Write-Host "`"$Directory`" already exists, no need to create it."
+    Write-Host "Directory `"$Directory`" already exists, no need to create it."
   } else {
-    Write-Host "`"$Directory`" does not exist, creating it.."
+    Write-Host "Directory `"$Directory`" does not exist, creating it.."
     New-Item -ItemType Directory -Force -Path $Directory | Out-Null
   }
+}
 
-  $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
-    $User, "FullControl", "ContainerInherit, ObjectInherit",
-    "None", "Allow")
+function Set-Permissions {
+  param([string] $Directory, [string] $User)
+
+  Write-Host "Attempting to grant `"$User`" full permissions to `"$Directory`"."
+
+  $rule = New-Object System.Security.AccessControl.FileSystemAccessRule($User, "FullControl", "ContainerInherit, ObjectInherit", "None", "Allow")
 
   try {
-    $acl = Get-Acl -Path  $Directory -ErrorAction Stop
+    $acl = Get-Acl -Path $Directory -ErrorAction Stop
+
+    # $acl.SetAccessRuleProtection($true, $false)
+    # $acl.Access | ForEach-Object { $acl.RemoveAccessRule($_) | Out-Null }
+
     $acl.SetAccessRule($rule)
-    Set-Acl -Path  $Directory -AclObject $acl -ErrorAction Stop
+
+    Set-Acl -Path $Directory -AclObject $acl -ErrorAction Stop
+
     Write-Host "Successfully set permissions on `"$Directory`"."
+
   } catch {
+
     throw "Failed to set permissions on `"$Directory`". Details: $_"
   }
 }
+function Install-Service-Files {
 
-function Set-Daemon-Permissions {
-  $daemonPath = "$(npm config get prefix --global)\node_modules\@innomizetech\pm2-windows-service\src\daemon"
-  Write-Host "Attempting to create `"$daemonPath`" and give FullControl to `"$User`""
+  # First, copy the service files
 
-  if (Test-Path $daemonPath) {
-    Write-Host "`"$daemonPath`" already exists, no need to create it."
-  } else {
-    Write-Host "`"$daemonPath`" does not exist, creating it.."
-    New-Item -ItemType Directory -Force -Path $daemonPath | Out-Null
-  }
+  $source = ".\src\windows\service\"
 
-  $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
-    $User, "FullControl", "ContainerInherit, ObjectInherit",
-    "None", "Allow")
+  Write-Host "Copying service files from `"$source`" to `"$PM2_SERVICE_DIRECTORY`".."
 
-  try {
-    $acl = (Get-Item $daemonPath).GetAccessControl('Access')
-    $acl.SetAccessRule($rule)
-    Set-Acl -Path $daemonPath -AclObject $acl -ErrorAction Stop
-    Write-Host "Successfully set permissions on `"$daemonPath`"."
-  } catch {
-    throw "Failed to set permissions on `"$daemonPath`". Details: $_"
-  }
-}
+  Copy-Item -Path $source\* -Destination $PM2_SERVICE_DIRECTORY -Recurse -Force
 
-function Set-NPM-Folder-Permissions {
-  $path = "$(npm config get prefix --global)"
-  Write-Host "Attempting to give FullControl of `"$path`" to `"$User`""
+  Write-Host "Copying files complete."
 
-  $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
-    $User, "FullControl", "ContainerInherit, ObjectInherit",
-    "None", "Allow")
+  # Next, link node-windows in that directory
 
-  try {
-    $acl = (Get-Item $path).GetAccessControl('Access')
-    $acl.SetAccessRule($rule)
-    Set-Acl -Path $path -AclObject $acl -ErrorAction Stop
-    Write-Host "Successfully set permissions on `"$path`"."
-  } catch {
-    throw "Failed to set permissions on `"$path`". Details: $_"
-  }
-
-  $path = "$(npm config get cache --global)"
-  Write-Host "Attempting to give FullControl of `"$path`" to `"$User`""
-
-  $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
-    $User, "FullControl", "ContainerInherit, ObjectInherit",
-    "None", "Allow")
-
-  try {
-    $acl = (Get-Item $path).GetAccessControl('Access')
-    $acl.SetAccessRule($rule)
-    Set-Acl -Path $path -AclObject $acl -ErrorAction Stop
-    Write-Host "Successfully set permissions on `"$path`"."
-  } catch {
-    throw "Failed to set permissions on `"$path`". Details: $_"
-  }
-}
-
-function Install-PM2-Service {
-  # Create wrapper log file, otherwise it won't start
-
-  $wrapperLogPath = "$(npm config get prefix --global)\node_modules\@innomizetech\pm2-windows-service\src\daemon\pm2.wrapper.log"
-
-  if (Test-Path $wrapperLogPath) {
-    Write-Debug "PM2 service wrapper log file already exists"
-  } else {
-    Write-Debug "PM2 service wrapper log file does not exist. Creating.."
-    Out-File $wrapperLogPath -Encoding utf8
-  }
-
-  # Ensure that the pm2-service-install command exists before attempting to invoke it
-
-  if ([bool](Get-Command "pm2-service-install" -ErrorAction SilentlyContinue) -eq $False) {
-    throw "pm2-windows-service is not installed."
-  }
-
-  Write-Host "Running pm2-service-install.."
-
-  # node-windows creates services with the current working directory
-  # pm2-service-install doesn't currently allow manually specifying the working directory when it invokes node-windows
-  # However, if we just cd into the correct place before creating the service, it's almost good enough
+  Write-Host "Service filed copied over. Linking node-windows in `"$PM2_SERVICE_DIRECTORY`".."
 
   $wd = (Get-Item -Path '.\' -Verbose).FullName
 
-  Set-Location $Directory
-
-  pm2-service-install --unattended
-
-  # Make sure this command succeeded
-
-  if ($? -ne $True) {
-
-    # Return back where we came from
-    Set-Location $wd
-
-    throw "pm2-service-install failed."
-  }
-
-  # Return back where we came from
+  Set-Location $PM2_SERVICE_DIRECTORY
+  npm link node-windows --loglevel=error --no-fund --no-audit
   Set-Location $wd
+
+  Write-Host "Linked node-windows in $PM2_SERVICE_DIRECTORY"
 }
 
-# Adapted from http://stackoverflow.com/a/4370900/964356
-function Set-ServiceUser {
-  param([string] $serviceName, [string] $username, [string] $pass)
+function Install-Service {
+  param([string] $Directory, [string] $User)
 
-  # Write-Host "Set-ServiceUser -serviceName `"$serviceName`" -username `"$username`""
+  Write-Host "Running Node service install script.."
+
+  $wd = (Get-Item -Path '.\' -Verbose).FullName
+
+  Set-Location $PM2_SERVICE_DIRECTORY
+  node "$wd\src\windows\service-management\install.js" $Directory $User
+  Set-Location $wd
+
+  if ($? -ne $True) {
+    throw "Service install script failed."
+  }
+}
+function Set-ServiceUser {
+  param([string] $name, [string] $username, [string] $pass)
+
+  # Write-Host "Set-ServiceUser -name `"$name`" -username `"$username`""
+  Write-Host "Updating `"$name`" service to run as `"$username`""
 
   # Create a filter to query for the service by
 
-  $filter = "Name='$serviceName'"
+  $filter = "Name='$name'"
 
   # Query for the service, wait a second if we can't find it right away
 
@@ -161,7 +112,7 @@ function Set-ServiceUser {
 
     if ($attempt -ne 0) {
       Start-Sleep -Milliseconds 1000
-      Write-Host "Attempt #$($attempt + 1) to locate `"$serviceName`" service.."
+      Write-Host "Attempt #$($attempt + 1) to locate `"$name`" service.."
     }
 
     $service = Get-WMIObject -class Win32_Service -Filter $filter
@@ -170,41 +121,18 @@ function Set-ServiceUser {
   }
 
   if ($null -eq $service) {
-    throw "Could not find `"$serviceName`" service after $maxAttempts attempts."
+    throw "Could not find `"$name`" service after $maxAttempts attempts."
   }
 
   # Now that we have a reference to the service, change it's user account
 
-  Write-Host "Found `"$serviceName`" service:"
+  Write-Host "Found `"$name`" service:"
   Write-Host "  State: $($service.State)"
   Write-Host "  Status: $($service.Status)"
   Write-Host "  Started: $($service.Started)"
   Write-Host "  Start Mode: $($service.StartMode)"
-  Write-Host "  Start Name: $($service.StartName)"
   Write-Host "  Service Type: $($service.ServiceType)"
-
-  # Stop the service
-  Write-Host "Stopping service.."
-
-  $response = $service.StopService()
-
-  if ($response.ReturnValue -ne 0) {
-    $message = Get-Service-Error-For-Code($response.ReturnValue)
-    throw "Could not stop service: $message"
-  }
-
-  # Wait until it has stopped
-
-  $service = Get-WMIObject -class Win32_Service -Filter $filter
-
-  Write-Host "  State is now: $($service.State)"
-
-  while ($service.State -ne 'Stopped') {
-
-    Start-Sleep -Milliseconds 250
-    $service = Get-WMIObject -class Win32_Service -Filter $filter
-    Write-Host "  State is now: $($service.State)"
-  }
+  Write-Host "  Start Name: $($service.StartName)"
 
   Write-Host "Changing service user account.."
 
@@ -215,7 +143,36 @@ function Set-ServiceUser {
     throw "Could not change service user: $message"
   }
 
-  # Start it up agian
+  # If the service isn't already stopped, stop it.
+
+  if ($service.State -ne 'Stopped') {
+
+    # Stop the service
+    Write-Host "Stopping service.."
+
+    $response = $service.StopService()
+
+    if ($response.ReturnValue -ne 0) {
+      $message = Get-Service-Error-For-Code($response.ReturnValue)
+      throw "Could not stop service: $message"
+    }
+
+    # Wait until it has stopped
+
+    $service = Get-WMIObject -class Win32_Service -Filter $filter
+
+    Write-Host "  State is now: $($service.State)"
+
+    while ($service.State -ne 'Stopped') {
+
+      Start-Sleep -Milliseconds 250
+      $service = Get-WMIObject -class Win32_Service -Filter $filter
+      Write-Host "  State is now: $($service.State)"
+    }
+  }
+
+  # Now, start it
+
   Write-Host "Starting service.."
 
   $response = $service.StartService()
@@ -238,20 +195,54 @@ function Set-ServiceUser {
     Write-Host "  State is now: $($service.State)"
   }
 
-  Write-Host "Service `"$serviceName`" is now running as `"$($service.StartName)`""
+  Write-Host "Service `"$name`" is now running as `"$($service.StartName)`"."
+}
+
+function Confirm-Service {
+  param([string] $name)
+
+  #Write-Host "Confirm-Service -name `"$name`""
+  Write-Host "Waiting a moment to confirm the`"$name`" service.."
+
+  # If the service is going to fail, it's likely going to fail within the first second.
+
+  # Wait a second
+  Start-Sleep -Milliseconds 1000
+
+  # Create a filter to query for the service by
+
+  $filter = "Name='$name'"
+
+  # Query for the service, wait a second if we can't find it right away
+
+  $attempt = 0
+  $maxAttempts = 10
+  $service = $null
+
+  while (($null -eq $service -and $attempt -le ($maxAttempts - 1))) {
+
+    if ($attempt -ne 0) {
+      Start-Sleep -Milliseconds 250
+      Write-Host "Attempt #$($attempt + 1) to locate `"$name`" service.."
+    }
+
+    $service = Get-WMIObject -class Win32_Service -Filter $filter
+
+    $attempt = $attempt + 1
+  }
+
+  if ($null -eq $service) {
+    throw "Could not find `"$name`" service after $maxAttempts attempts."
+  }
+
+  Write-Host "Service `"$name`":"
   Write-Host "  State: $($service.State)"
   Write-Host "  Status: $($service.Status)"
   Write-Host "  Started: $($service.Started)"
   Write-Host "  Start Mode: $($service.StartMode)"
   Write-Host "  Service Type: $($service.ServiceType)"
+  Write-Host "  Start Name: $($service.StartName)"
 }
-
-function Set-PM2-Service-Account {
-  Write-Host "Changing PM2 to run as `"$User`""
-  Set-ServiceUser -serviceName "pm2.exe" -username $User -pass ""
-}
-
-# https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/startservice-method-in-class-win32-service
 function Get-Service-Error-For-Code {
   param([int] $code = 0)
 
@@ -285,23 +276,59 @@ function Get-Service-Error-For-Code {
   }
 }
 
-$env:PM2_HOME = $Directory
-$env:PM2_SERVICE_PM2_DIR = "$(npm config get prefix --global)\node_modules\pm2\index.js"
-# $env:PM2_SERVICE_SCRIPTS = " $Directory\ecosystem.json"
 
-[Environment]::SetEnvironmentVariable("PM2_HOME", $env:PM2_HOME, "Machine")
-[Environment]::SetEnvironmentVariable("PM2_SERVICE_PM2_DIR", $env:PM2_SERVICE_PM2_DIR, "Machine")
-# [Environment]::SetEnvironmentVariable("PM2_SERVICE_SCRIPTS", $env:PM2_SERVICE_SCRIPTS, "Machine")
+Write-Host "=== Creating Service ==="
 
-[Environment]::SetEnvironmentVariable("SET_PM2_HOME", "true", "Machine")
-[Environment]::SetEnvironmentVariable("SET_PM2_SERVICE_PM2_DIR", "true", "Machine")
-[Environment]::SetEnvironmentVariable("SET_PM2_SERVICE_SCRIPTS", "false", "Machine")
+# Discern where pm2 is installed
+# Presumably this should be C:\ProgramData\npm\npm\, but we don't want to make any assumptions
+Write-Host "Determining pm2 installation directory.."
+$PM2_INSTALL_DIRECTORY = "$(npm config get prefix --global)\node_modules\pm2"
 
-& New-PM2-Home
-& Set-NPM-Folder-Permissions
-& Set-Daemon-Permissions
-& Install-PM2-Service
-& Set-PM2-Service-Account
+# Query for the name of the Local Service user by its security identifier
+# https://support.microsoft.com/en-us/help/243330/well-known-security-identifiers-in-windows-operating-systems
+# In English, this is "NT AUTHORITY\LOCAL SERVICE", but in Norwegian it's "NT-MYNDIGHET\LOKAL TJENESTE"
+Write-Host "Determining Local Service user name (`"S-1-5-19`").."
+$localServiceSID = New-Object System.Security.Principal.SecurityIdentifier("S-1-5-19")
+$ServiceUser = ($localServiceSID.Translate([System.Security.Principal.NTAccount])).Value
+
+# Print out configuration
+Write-Host "Configuration:"
+Write-Host "  PM2_HOME:              $PM2_HOME"
+Write-Host "  PM2_SERVICE_DIRECTORY: $PM2_SERVICE_DIRECTORY"
+Write-Host "  PM2_INSTALL_DIRECTORY: $PM2_INSTALL_DIRECTORY"
+Write-Host "  Service User:          $ServiceUser"
+Write-Host ""
+
+# Set the environmental variables we need (PM2_HOME, PM2_SERVICE_DIRECTORY and PM2_INSTALL_DIRECTORY) on a machine level
+Set-Env
+
+# Create the pm2\home and pm2\service folders
+New-Directory -Directory $PM2_HOME
+New-Directory -Directory $PM2_SERVICE_DIRECTORY
+
+# Copy the service source code into the pm2\service folder, and link node-windows
+Install-Service-Files
+
+# Set permissions on pm2\home and pm2\service
+Set-Permissions -Directory $PM2_HOME -User $ServiceUser
+Set-Permissions -Directory $PM2_SERVICE_DIRECTORY -User $ServiceUser
+
+# Create the service itself
+# Install-Service -Directory $PM2_SERVICE_DIRECTORY -User $ServiceUser
+Install-Service -Directory $PM2_SERVICE_DIRECTORY
+# There is currently (May 2020) an issue with the way that node-windows uses user credentials.
+# Sending it the local service user fails, so instead we let it start as LocalSystem
+# --then switch the user the service runs as afterwards
+
+# Do this again, because installing the service adds a few files
+Set-Permissions -Directory $PM2_HOME -User $ServiceUser
+Set-Permissions -Directory $PM2_SERVICE_DIRECTORY -User $ServiceUser
+
+# Switch the service user to Local Service
+Set-ServiceUser -name "pm2.exe" -username $ServiceUser -pass ""
+
+# Confirm the service is running
+Confirm-Service -name "pm2.exe"
 
 # Finally, invoke pm2 directly
 pm2 list

--- a/src/windows/setup-service.ps1
+++ b/src/windows/setup-service.ps1
@@ -66,15 +66,15 @@ function Install-Service-Files {
 
   # Next, link node-windows in that directory
 
-  Write-Host "Service filed copied over. Linking node-windows in `"$PM2_SERVICE_DIRECTORY`".."
+  # Write-Host "Service filed copied over. Linking node-windows in `"$PM2_SERVICE_DIRECTORY`".."
 
-  $wd = (Get-Item -Path '.\' -Verbose).FullName
+  # $wd = (Get-Item -Path '.\' -Verbose).FullName
 
-  Set-Location $PM2_SERVICE_DIRECTORY
-  npm link node-windows --loglevel=error --no-fund --no-audit
-  Set-Location $wd
+  # Set-Location $PM2_SERVICE_DIRECTORY
+  # npm link node-windows --loglevel=error --no-fund --no-audit
+  # Set-Location $wd
 
-  Write-Host "Linked node-windows in $PM2_SERVICE_DIRECTORY"
+  # Write-Host "Linked node-windows in $PM2_SERVICE_DIRECTORY"
 }
 
 function Install-Service {

--- a/src/windows/setup.ps1
+++ b/src/windows/setup.ps1
@@ -4,7 +4,7 @@ Write-Host "=== Setup ==="
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
 
 # Check the npm configuration to ensure the prefix isn't in the current user's appdata folder
-$continue = &".\src\windows\configure-check.ps1" | select -Last 1
+$continue = &".\src\windows\configure-check.ps1" | Select-Object -Last 1
 
 if ($continue -eq 'n') {
   Write-Host "=== Setup Canceled ==="

--- a/src/windows/versions.ps1
+++ b/src/windows/versions.ps1
@@ -1,8 +1,8 @@
-$pm2_package = "$(node src/dependency.js pm2)"
-$pm2_service_package = "$(node src/dependency.js pm2-windows-service)";
-$pm2_logrotate_package = "$(node src/dependency.js pm2-logrotate)"
+$pm2_package = "$(node src/tools/echo-dependency.js pm2)"
+$pm2_logrotate_package = "$(node src/tools/echo-dependency.js pm2-logrotate)"
+$node_windows_package = "$(node src/tools/echo-dependency.js node-windows windows)"
 
 Write-Host "Using:"
 Write-Host "- $pm2_package"
-Write-Host "- $pm2_service_package"
 Write-Host "- $pm2_logrotate_package"
+Write-Host "- $node_windows_package"


### PR DESCRIPTION
`pm2-installer` now ships with a new Windows service that leverages the most recent version of `node-windows`.

`pm2-windows-service` was great, but it's completely unmaintained. There are a few promising forks, but none seem to be working correctly with Node 14 right now.

The new service has no dependencies, and only requires `node-windows` to install & uninstall.

This fixes #3, and should make maintenance a lot smoother in the future.
