### PR TITLE
Fix "Service Dependency Failure" on Windows 

### DIFF
--- a/src/windows/check-service.ps1
+++ b/src/windows/check-service.ps1
@@ -15,8 +15,8 @@ $service = $null
 while (($null -eq $service -and $attempt -le ($maxAttempts - 1))) {
 
   if ($attempt -ne 0) {
-    Start-Sleep -Milliseconds 250
-    Write-Host "Attempt #$($attempt + 1) to locate `"$name`" service.."
+    Start-Sleep -Milliseconds 100
+    Write-Host "Attempt #$($attempt) to locate service `"$name`" failed, trying again.."
   }
 
   $service = Get-WMIObject -class Win32_Service -Filter $filter
@@ -29,9 +29,37 @@ if ($null -eq $service) {
 }
 
 Write-Host "Found `"$name`" service:"
+
 Write-Host "  State: $($service.State)"
 Write-Host "  Status: $($service.Status)"
 Write-Host "  Started: $($service.Started)"
 Write-Host "  Start Mode: $($service.StartMode)"
 Write-Host "  Service Type: $($service.ServiceType)"
 Write-Host "  Start Name: $($service.StartName)"
+Write-Host ""
+Write-Host "  Display Name: $($service.DisplayName)"
+Write-Host "  Description: $($service.Description)"
+Write-Host "  Path Name: $($service.PathName)"
+Write-Host "  System Name: $($service.SystemName)"
+Write-Host "  Install Date: $($service.InstallDate)"
+Write-Host "  Check Point: $($service.CheckPoint)"
+Write-Host "  Service Specific Exit Code: $($service.ServiceSpecificExitCode)"
+Write-Host "  Exit Code: $($service.ExitCode)"
+
+
+$service = Get-Service $name
+if ($service.RequiredServices) {
+  write-Host "  Requires:"
+  foreach ($item in $service.RequiredServices) {
+    Write-Host "    $($item.name)"
+  }
+}
+
+if ($service.DependentServices) {
+  write-Host "  Depended on by:"
+  foreach ($item in $service.DependentServices) {
+    Write-Host "    $($item.name)"
+  }
+}
+
+Write-Host ""

--- a/src/windows/setup-service.ps1
+++ b/src/windows/setup-service.ps1
@@ -317,15 +317,19 @@ Set-Permissions -Directory $PM2_SERVICE_DIRECTORY -User $ServiceUser
 # Install-Service -Directory $PM2_SERVICE_DIRECTORY -User $ServiceUser
 Install-Service -Directory $PM2_SERVICE_DIRECTORY
 # There is currently (May 2020) an issue with the way that node-windows uses user credentials.
-# Sending it the local service user fails, so instead we let it start as LocalSystem
-# --then switch the user the service runs as afterwards
+# Sending it the local service user fails, so instead:
+# - Create the service to run as LocalSystem, but don't start it
+# - Update the service to run as the LocalService user
+# - Start the service
+# Starting the service as LocalSystem then attempting to change it to LocalService causes permissions issues
+# However, if the service never starts until after being updated to run as LocalService, it works perfectly
 
 # Do this again, because installing the service adds a few files
 Set-Permissions -Directory $PM2_HOME -User $ServiceUser
 Set-Permissions -Directory $PM2_SERVICE_DIRECTORY -User $ServiceUser
 
 # Switch the service user to Local Service
-Set-ServiceUser -name "pm2.exe" -username $ServiceUser -pass ""
+Set-ServiceUser -name "pm2.exe" -username "NT AUTHORITY\LocalService" -pass ""
 
 # Confirm the service is running
 Confirm-Service -name "pm2.exe"


### PR DESCRIPTION
When installing on a Windows system where the base language wasn't English, the service would fail to start and throw a "Service Dependency Failure".

Fixes #5 