### PR TITLE
Fix infinite freeze on server 2016

### DIFF
--- a/src/windows/setup-service.ps1
+++ b/src/windows/setup-service.ps1
@@ -334,7 +334,4 @@ Set-ServiceUser -name "pm2.exe" -username "NT AUTHORITY\LocalService" -pass ""
 # Confirm the service is running
 Confirm-Service -name "pm2.exe"
 
-# Finally, invoke pm2 directly
-pm2 list
-
 Write-Host "=== Creating Service Complete ==="


### PR DESCRIPTION
Install doesn't complete with this line but works fine without it.

Confirmed bug and fix on 6 different windows server 2016 computers.