### PR TITLE
Support specifying the service name & description

### DIFF
--- a/src/windows/remove-service.ps1
+++ b/src/windows/remove-service.ps1
@@ -2,6 +2,7 @@ Write-Host "=== Remove Service ==="
 
 $PM2_HOME = $env:PM2_HOME;
 $PM2_SERVICE_DIRECTORY = $env:PM2_SERVICE_DIRECTORY;
+$PM2_SERVICE_NAME = $env:PM2_SERVICE_NAME;
 
 function Stop-Service {
   param([string] $name)
@@ -85,7 +86,7 @@ if (($null -ne $PM2_SERVICE_DIRECTORY) -and (Test-Path $PM2_SERVICE_DIRECTORY)) 
 
 Write-Host "Running Node service uninstall script.."
 
-node "$wd\src\windows\service-management\uninstall.js" $PM2_SERVICE_DIRECTORY
+node "$wd\src\windows\service-management\uninstall.js" $PM2_SERVICE_DIRECTORY $PM2_SERVICE_NAME
 
 if ($? -ne $True) {
   Set-Location $wd

--- a/src/windows/service-management/install.js
+++ b/src/windows/service-management/install.js
@@ -22,7 +22,7 @@ for (const key of ['PM2_HOME', 'PM2_INSTALL_DIRECTORY', 'PM2_SERVICE_DIRECTORY']
   }
 }
 
-let [directory, user, name, description] = process.argv.slice(2);
+let [directory, name, description, user] = process.argv.slice(2);
 
 // Pull the process directory, service name, and service description from the script parameters or pricess env, or use a default
 directory = directory || process.env.PM2_SERVICE_DIRECTORY || 'c:\\ProgramData\\pm2\\service\\';

--- a/src/windows/service-management/uninstall.js
+++ b/src/windows/service-management/uninstall.js
@@ -14,7 +14,7 @@ const { Service } = require('node-windows');
 
 // Create a "Service" object
 
-let [directory, user, name, description] = process.argv.slice(2);
+let [directory, name, description, user] = process.argv.slice(2);
 
 // Pull the process directory, service name, and service description from the script parameters or pricess env, or use a default
 directory = directory || process.env.PM2_SERVICE_DIRECTORY || 'c:\\ProgramData\\pm2\\service\\';

--- a/src/windows/setup-service.ps1
+++ b/src/windows/setup-service.ps1
@@ -78,14 +78,19 @@ function Install-Service-Files {
 }
 
 function Install-Service {
-  param([string] $Directory, [string] $User)
+  param(
+    [string] $Directory,
+    [string] $Name = "PM2",
+    [string] $Description = "Node process manager",
+    [string] $User
+  )
 
   Write-Host "Running Node service install script.."
 
   $wd = (Get-Item -Path '.\' -Verbose).FullName
 
   Set-Location $PM2_SERVICE_DIRECTORY
-  node "$wd\src\windows\service-management\install.js" $Directory $User
+  node "$wd\src\windows\service-management\install.js" $Directory $Name $Description $User
   Set-Location $wd
 
   if ($? -ne $True) {
@@ -315,7 +320,7 @@ Set-Permissions -Directory $PM2_SERVICE_DIRECTORY -User $ServiceUser
 
 # Create the service itself
 # Install-Service -Directory $PM2_SERVICE_DIRECTORY -User $ServiceUser
-Install-Service -Directory $PM2_SERVICE_DIRECTORY
+Install-Service -Directory $PM2_SERVICE_DIRECTORY # -Name $ServiceName -Description $ServiceDescription
 # There is currently (May 2020) an issue with the way that node-windows uses user credentials.
 # Sending it the local service user fails, so instead:
 # - Create the service to run as LocalSystem, but don't start it


### PR DESCRIPTION
# Description

> What has changed in this PR?

Add the ability to specify the name and description of the Windows service on setup

## Type

> Does this fix bugs or add new features? Link any appropriate issues

Feature.
Fixes: https://github.com/jessety/pm2-installer/issues/23, https://github.com/jessety/pm2-installer/issues/46

## Testing

> Which environments has this change been tested in?

TBD


This is a work in progress. I still need to enable using this from the `setup` command, and test across different versions of Windows.
