### PR TITLE
Migrate from `pm2-logrotate` to `@jessety/pm2-logrotate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ npm run setup
 
 That's it.
 
+> NOTE: Running `npm install` is not necessary, unless you're developing `pm2-installer` itself and want to lint the project.
+
 ### Offline Install
 
 `pm2-installer` is also designed to function without an internet connection. It does this by creating a cache on an internet-connected build machine, then installing from that cache when run on the offline deployment machine.

--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
     "remove:default": "echo 'ERROR: Could not detect host platform'"
   },
   "dependencies": {
-    "pm2": "5.1.0",
-    "pm2-logrotate": "2.7.0",
-    "node-windows": "1.0.0-beta.1"
+    "@jessety/pm2-logrotate": "^2.7.1",
+    "node-windows": "1.0.0-beta.1",
+    "pm2": "5.1.0"
   },
   "devDependencies": {
     "@jessety/eslint-config": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/sponsors/jessety"
   },
   "scripts": {
-    "postinstall": "echo 'Installing this package is not necessary. Run \"npm run setup\" to install pm2.'",
+    "preinstall": "echo WARNING: Running install in this project is not necessary. See README.",
     "lint": "eslint . && editorconfig-checker .",
     "info": "node ./src/bundle-info/current.js",
     "info-config": "PowerShell -NoProfile -ExecutionPolicy Bypass src\\windows\\info-config.ps1",

--- a/src/unix/bundle.sh
+++ b/src/unix/bundle.sh
@@ -3,7 +3,7 @@
 echo "=== Bundle ==="
 
 pm2_package=$(node src/tools/echo-dependency.js pm2)
-pm2_logrotate_package=$(node src/tools/echo-dependency.js pm2-logrotate)
+pm2_logrotate_package=$(node src/tools/echo-dependency.js @jessety/pm2-logrotate)
 
 cache_folder="./.npm_cache";
 cache_archive="./bundle.tar.gz"

--- a/src/unix/setup.sh
+++ b/src/unix/setup.sh
@@ -3,7 +3,7 @@
 echo "=== Setup ==="
 
 pm2_package=$(node src/tools/echo-dependency.js pm2)
-pm2_logrotate_package=$(node src/tools/echo-dependency.js pm2-logrotate)
+pm2_logrotate_package=$(node src/tools/echo-dependency.js @jessety/pm2-logrotate)
 
 cache_folder="./.npm_cache";
 cache_archive="./bundle.tar.gz"

--- a/src/windows/bundle.ps1
+++ b/src/windows/bundle.ps1
@@ -3,7 +3,7 @@ Write-Host "=== Bundle ==="
 $Epoch = Get-Date
 
 $pm2_package = "$(node src/tools/echo-dependency.js pm2)"
-$pm2_logrotate_package = "$(node src/tools/echo-dependency.js pm2-logrotate)"
+$pm2_logrotate_package = "$(node src/tools/echo-dependency.js @jessety/pm2-logrotate)"
 $node_windows_package = "$(node src/tools/echo-dependency.js node-windows)"
 
 $cache_folder = ".\.npm_cache";
@@ -45,7 +45,6 @@ $BeforePopulation = Get-Date
 npm install --no-save --global-style --force --cache $cache_folder --shrinkwrap false --loglevel=error --no-audit --no-fund $pm2_package
 npm install --no-save --global-style --force --cache $cache_folder --shrinkwrap false --loglevel=error --no-audit --no-fund $pm2_logrotate_package
 npm install --no-save --global-style --force --cache $cache_folder --shrinkwrap false --loglevel=error --no-audit --no-fund $node_windows_package
-
 Write-Host "Populating cache took $([Math]::Floor($(Get-Date).Subtract($BeforePopulation).TotalSeconds)) seconds."
 
 if (Get-Command "tar.exe" -ErrorAction SilentlyContinue) {

--- a/src/windows/setup-logrotate.ps1
+++ b/src/windows/setup-logrotate.ps1
@@ -5,7 +5,7 @@ node src\tools\npm-online.js
 
 if ($? -eq $True) {
 
-  $logrotate_package = "$(node src/tools/echo-dependency.js pm2-logrotate)"
+  $logrotate_package = "$(node src/tools/echo-dependency.js @jessety/pm2-logrotate)"
 
   Write-Host "Installing $logrotate_package online.."
 

--- a/src/windows/setup-packages.ps1
+++ b/src/windows/setup-packages.ps1
@@ -3,7 +3,7 @@ Write-Host "=== Install Packages ==="
 $Epoch = Get-Date
 
 $pm2_package = "$(node src/tools/echo-dependency.js pm2)"
-$pm2_logrotate_package = "$(node src/tools/echo-dependency.js pm2-logrotate)"
+$pm2_logrotate_package = "$(node src/tools/echo-dependency.js @jessety/pm2-logrotate)"
 $node_windows_package = "$(node src/tools/echo-dependency.js node-windows)"
 
 $cache_folder = ".\.npm_cache"

--- a/src/windows/versions.ps1
+++ b/src/windows/versions.ps1
@@ -1,5 +1,5 @@
 $pm2_package = "$(node src/tools/echo-dependency.js pm2)"
-$pm2_logrotate_package = "$(node src/tools/echo-dependency.js pm2-logrotate)"
+$pm2_logrotate_package = "$(node src/tools/echo-dependency.js @jessety/pm2-logrotate)"
 $node_windows_package = "$(node src/tools/echo-dependency.js node-windows)"
 
 Write-Host "Using:"


### PR DESCRIPTION
# Description

`pm2-logrotate` has been unmaintained since 2019, and has had a critical issue on Windows for a long time now where the older log files simply would not be deleted. [@jessety/pm2-logrotate](https://www.npmjs.com/package/@jessety/pm2-logrotate) is a new fork that corrects that issue.

## Type

Fixes bugs. See:
https://github.com/keymetrics/pm2-logrotate/issues/170
https://github.com/keymetrics/pm2-logrotate/issues/169

Logrotate doesn't seem to have any other viable forks at the moment. See:
https://github.com/keymetrics/pm2-logrotate/issues/173

## Testing

Tested on Windows 10 Pro and Server 2016.
