### PR TITLE
Update setup-logrotate.ps1

### DIFF
--- a/src/windows/setup-logrotate.ps1
+++ b/src/windows/setup-logrotate.ps1
@@ -13,7 +13,7 @@ if ($? -eq $True) {
 
 } else {
 
-  $logrotate_directory = "$(npm config get prefix)\node_modules\pm2-logrotate\"
+  $logrotate_directory = "$(npm config get prefix)\node_modules\@jessety\pm2-logrotate\"
 
   Write-Host "Installing pm2-logrotate locally in directory: $logrotate_directory"
 


### PR DESCRIPTION
# Description

> When offline install, can not find logrotate_directory
> local directory: $(npm config get prefix)\node_modules\\@jessety\pm2-logrotate\

## Type

> fix bug

## Testing

> windows 10
