### PR TITLE
Don't install dev deps when linking `node-windows`

### DIFF
--- a/src/windows/setup-packages.ps1
+++ b/src/windows/setup-packages.ps1
@@ -119,7 +119,7 @@ if ($? -eq $True) {
 }
 
 Write-Host "Linking node-windows.."
-npm link node-windows --loglevel=error --no-fund --no-audit
+npm link node-windows --loglevel=error --no-fund --no-audit --production
 
 # Enable execution of pm2's powershell script, so the current user can interact with the pm2 powershell script
 $script_path = "$(npm config get prefix)\pm2.ps1"

--- a/src/windows/setup-packages.ps1
+++ b/src/windows/setup-packages.ps1
@@ -119,7 +119,7 @@ if ($? -eq $True) {
 }
 
 Write-Host "Linking node-windows.."
-npm link node-windows --loglevel=error --no-fund --no-audit --production
+npm link node-windows --loglevel=error --no-fund --no-audit --production --offline
 
 # Enable execution of pm2's powershell script, so the current user can interact with the pm2 powershell script
 $script_path = "$(npm config get prefix)\pm2.ps1"


### PR DESCRIPTION
# Description

Fix issue that complicated offline installations on Windows

## Type

Fixes https://github.com/jessety/pm2-installer/issues/29

## Testing

Windows 10
