### PR TITLE
Ability to change the PM2 Service User

### DIFF
--- a/src/windows/setup-service.ps1
+++ b/src/windows/setup-service.ps1
@@ -329,7 +329,9 @@ Set-Permissions -Directory $PM2_HOME -User $ServiceUser
 Set-Permissions -Directory $PM2_SERVICE_DIRECTORY -User $ServiceUser
 
 # Switch the service user to Local Service
-Set-ServiceUser -name "pm2.exe" -username "NT AUTHORITY\LocalService" -pass ""
+$PM2ServiceAccount = ($Env:PM2_SERVICE_ACCOUNT, "NT AUTHORITY\LocalService" -ne $null )[0]
+$PM2ServiceAccountPassword = ($Env:PM2_SERVICE_ACCOUNT_PASSWORD, "" -ne $null )[0]
+Set-ServiceUser -name "pm2.exe" -username $PM2ServiceAccount -pass $PM2ServiceAccountPassword
 
 # Confirm the service is running
 Confirm-Service -name "pm2.exe"


### PR DESCRIPTION
I would like to be able to change the service user from the session environment variable. 

We sometimes need to use a domain user as an app may need access to files / folders on the network not just the local machine

The code is effectively using coalesce to return the PM2_SERVICE_ACCOUNT and password from $Env and if it's not available, it will default to the LocalService user.


## Type
New Feature

## Testing
Local