### PR TITLE
build(.github/dependabot): enable github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,9 @@ updates:
       - dependency-type: "production"
     reviewers:
       - "jessety"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "jessety"


### PR DESCRIPTION
# Description

Updates the Dependabot config so that it will open PRs for GitHub Actions, i.e. bumping actions/checkout from v2 to v3
