### PR TITLE
ci: use major version of `actions/setup-node`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Node
-        uses: actions/setup-node@v3.1.1
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
       - name: Install development dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0 # Git history won't be fetched without this option
 
       - name: Setup Node
-        uses: actions/setup-node@v3.1.1
+        uses: actions/setup-node@v3
 
       - name: Generate release notes # To change the release notes format, edit RELEASE.md.hbs
         id: notes


### PR DESCRIPTION
# Description

Dependabot had a wobble, this will ensure that `actions/setup-node` uses the latest semver tag in v3.x.x without requiring another Dependabot PR.

