### PR TITLE
Fix issue that causes offline un-installations to fail

### DIFF
--- a/src/windows/remove-packages.ps1
+++ b/src/windows/remove-packages.ps1
@@ -2,7 +2,18 @@ Write-Host "=== Remove Packages ==="
 
 Write-Host "Unlinking node-windows.."
 
+
+# Strip dependencies from package.json
+# This is because `npm unlink` fails while attempting to negotiate dev dependencies that aren't cached when offline
+Write-Host "Stripping dependencies..."
+node src\tools\dependencies\strip.js
+
+Write-Host "Linking node-windows.."
 npm unlink node-windows --loglevel=error --no-fund --no-audit
+
+  # Restore dependencies to package.json
+Write-Host "Restoring dependencies..."
+node src\tools\dependencies\restore.js
 
 Write-Host "Uninstalling packages.."
 

--- a/src/windows/setup-packages.ps1
+++ b/src/windows/setup-packages.ps1
@@ -116,7 +116,7 @@ if ($? -eq $True) {
   Write-Host "Installing packages took $([Math]::Floor($(Get-Date).Subtract($PriorToInstall).TotalSeconds)) seconds."
 
   # Strip dependencies from package.json
-  # This is because `node link` fails while attempting to install dev dependencies that aren't cached when offline
+  # This is because `npm link` fails while attempting to install dev dependencies that aren't cached when offline
   Write-Host "Stripping dependencies..."
   node src\tools\dependencies\strip.js
 


### PR DESCRIPTION
# Description

<!--  What has changed in this PR? -->

Offline uninstallations would fail for the same reasons that offline installations were failing prior to https://github.com/jessety/pm2-installer/pull/73

## Testing

<!--  Which environments has this change been tested in? -->

Windows 10, Windows 11

## Fixes or features?

<!-- Does this fix bugs or add new features? Link any appropriate issues -->
